### PR TITLE
Add exception to disable the `destructuring-assignment` rule for class fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   extends: ['airbnb', 'plugin:prettier/recommended', 'prettier/react'],
   rules: {
     'prettier/prettier': ['error', prettierConfig],
+    'react/destructuring-assignment': [2, 'always', { ignoreClassFields: true }],
     'react/jsx-filename-extension': 0,
     'no-use-before-define': 0,
     'jsx-a11y/label-has-for': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.0
+## Add exception to disable the `destructuring-assignment` rule for class fields
+
 # v0.3.0
 ## Add default `prettier` config
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
Rule documentation: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md#rule-options

This change allows declaring class properties without descructuring, making it possible to set class fields based on props without having to declare a constructor.