### PR TITLE
Add curly rule for consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,6 @@ module.exports = {
       },
     ],
     'import/prefer-default-export': 0,
-    curly: [1, 'all', 'multi-line'],
+    curly: [1, 'all'],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,6 @@ module.exports = {
       },
     ],
     'import/prefer-default-export': 0,
+    curly: [1, 'all', 'multi-line'],
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.4.1
+# v1.0.0
 ## Add `curly` rule for consistency
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.1
+## Add `curly` rule for consistency
+
 # v0.4.0
 ## Add exception to disable the `destructuring-assignment` rule for class fields
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
Prevent:

```javascript
if (foo) foo++;
```

in favour of:

```javascript
if (foo) {
    foo++;
}
```