### PR TITLE
Update deprecated jsx-a11y/label-has-for

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     'react/destructuring-assignment': [2, 'always', { ignoreClassFields: true }],
     'react/jsx-filename-extension': 0,
     'no-use-before-define': 0,
-    'jsx-a11y/label-has-for': [
+    'jsx-a11y/label-has-associated-control': [
       2,
       {
         required: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,9 +16,7 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': [
       2,
       {
-        required: {
-          some: ['nesting', 'id'],
-        },
+        assert: 'either',
       },
     ],
     'import/prefer-default-export': 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.0
+## Use `jsx-a11y/label-has-associated-control` in favour of deprecated `jsx-a11y/label-has-for`
+
 # v1.0.0
 ## Add `curly` rule for consistency
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
`jsx-a11y/label-has-for` was deprecated in `eslint-plugin-jsx-a11y` `v6.1.0`. Updating to recommended rule.