### PR TITLE
Fix mutation rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
       {
         commonjs: true,
         allowThis: true,
+        exceptions: [{ property: 'propTypes' }, { property: 'defaultProps' }],
       },
     ],
     'fp/no-mutating-assign': 'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.0.1
+## Don't apply mutation rules for propTypes and defaultProps
+
 # v5.0.0
 ## Add rules to mitigate pitfalls of object mutation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context
<!-- why this change is made --> 
Follow-up for https://github.com/transferwise/eslint-config/pull/15

## 🚀 Changes
<!-- what this PR does -->
Adds exceptions for propTypes and defaultProps as they're valid uses of object mutation.

## ✅ Checklist

- [x] The package version is bumped according to [semver](https://semver.org) in `package.json`, `package-lock.json`, and `CHANGELOG.md`
