### PR TITLE
Don't apply mutation rules for window

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,12 @@ module.exports = {
       {
         commonjs: true,
         allowThis: true,
-        exceptions: [{ property: 'propTypes' }, { property: 'defaultProps' }],
+        exceptions: [
+          { property: 'propTypes' },
+          { property: 'defaultProps' },
+          { object: 'global' },
+          { object: 'window' },
+        ],
       },
     ],
     'fp/no-mutating-assign': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,12 +28,7 @@ module.exports = {
       {
         commonjs: true,
         allowThis: true,
-        exceptions: [
-          { property: 'propTypes' },
-          { property: 'defaultProps' },
-          { object: 'global' },
-          { object: 'window' },
-        ],
+        exceptions: [{ property: 'propTypes' }, { property: 'defaultProps' }, { object: 'window' }],
       },
     ],
     'fp/no-mutating-assign': 'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.0.2
+## Don't apply mutation rules for window
+
 # v5.0.1
 ## Don't apply mutation rules for propTypes and defaultProps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context
<!-- why this change is made --> 
* `window` has valid uses like assigning `window.location.href` to trigger a navigation
* `window` is not a risk vector as it doesn't come into play for SSR

## 🚀 Changes
<!-- what this PR does -->
Adds an exeption for `window` to `fp/no-mutation`


## ✅ Checklist

- [x] The package version is bumped according to [semver](https://semver.org) in `package.json`, `package-lock.json`, and `CHANGELOG.md`
