### PR TITLE
Don't apply mutation rules for getInitialProps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,12 @@ module.exports = {
       {
         commonjs: true,
         allowThis: true,
-        exceptions: [{ property: 'propTypes' }, { property: 'defaultProps' }, { object: 'window' }],
+        exceptions: [
+          { property: 'propTypes' },
+          { property: 'defaultProps' },
+          { property: 'getInitialProps' },
+          { object: 'window' },
+        ],
       },
     ],
     'fp/no-mutating-assign': 'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v5.0.2
+# v5.0.3
 ## Don't apply mutation rules for getInitialProps
 
 # v5.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v5.0.2
+## Don't apply mutation rules for getInitialProps
+
+# v5.0.2
 ## Don't apply mutation rules for window
 
 # v5.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/eslint-config",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "TransferWise ESLint & Prettier configuration",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context
<!-- why this change is made --> 
`getInitialProps` is a valid use for reassignment.

## 🚀 Changes
<!-- what this PR does -->
adds `{ property: 'getInitialProps' }` to exceptions

## ✅ Checklist

- [x] The package version is bumped according to [semver](https://semver.org) in `package.json`, `package-lock.json`, and `CHANGELOG.md`
