### PR TITLE
Disables jest/require-top-level-describe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     ],
     'jest/valid-title': ['error', { ignoreTypeOfDescribeName: true }], // to support using a function as a title, which prevents titles from getting out of date
     'jest/prefer-expect-assertions': 'off', // too verbose for every test
+    'jest/require-top-level-describe': 'off', // using `test` or hooks outside of a describe block is fine in smaller test files
     'jest/no-hooks': 'off', // we're using them for setup, up for consideration
     'jest/lowercase-name': [
       'error',


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context
`jest/require-top-level-describe` is overly prescriptive - there are plenty of cases where top level `test` and hooks are perfectly valid and don't lead to code organisation/navigation issues.

## 🚀 Changes
- [x] Turns off `jest/require-top-level-describe`

## 💬 Considerations
<!-- additional info for reviewing, discussion topics -->

## ✅ Checklist

- [ ] The package version is bumped according to [semver](https://semver.org) in `package.json`, and `CHANGELOG.md`
